### PR TITLE
Update to Scala 3.3.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val scala3Version = "3.2.0"
+val scala3Version = "3.3.0"
 
 lazy val commonSettings = Seq(
     organization := "org.justinhj",


### PR DESCRIPTION
This updates from 3.2 to 3.3.0. 

https://www.scala-lang.org/blog/2023/05/30/scala-3.3.0-released.html
